### PR TITLE
Fix for record count not displaying

### DIFF
--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -38,7 +38,7 @@ function getNotifications (username, callback) {
     if (newDone === true && partialDone === true && fileDone === true && dupeDone === true) {
       var recCount = {
         unreviewed_merges: partialCount,
-        new_merges: newCount,
+        new_count: newCount,
         duplicate_merges: dupeCount,
         file_count: fileCount,
       };


### PR DESCRIPTION
I noticed the record count on the dashboard and nav were referencing a different name then the notification api is sending.  I changed the notification api so it matches the UI.