### PR TITLE
Update main.yml

### DIFF
--- a/deploy/ansible/roles/dre/tasks/main.yml
+++ b/deploy/ansible/roles/dre/tasks/main.yml
@@ -23,7 +23,7 @@
   git: repo="git://github.com/amida-tech/DRE.git" dest="/var/www/dre/source" #version="v1.3.1"
 
 - name: Copy DRE source to current
-  command: cp -r /var/www/dre/source/. /var/www/dre/current
+  command: cp -r /var/www/dre/source/DRE/. /var/www/dre/current
 
 - name:  Install grunt CLI tools
   sudo: yes


### PR DESCRIPTION
Dmitry,

Jon here from LHD. The deploy scripts from the master branch work fine with two exceptions:

1) cloning from GitHub failed, due to the remote key not being known (see ansible/ansible#7474), 
2) the source code needs to be obtained from a subfolder named DRE.

Couldn't fix the first problem, but this fix should be all good to go for the second.

:)

Jon

---

Cloning from GitHub puts the source code in a subfolder named DRE, hence, need to copy the source code from the DRE subfolder to the target, "/var/www/dre/current"