### PR TITLE
Code Coverage with Istanbul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ bower_components
 server/coverage
 client/coverage
 coverage
+test/coverage
 .DS_Store
 
 */**/.DS_Store

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,9 +5,11 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-watch');
     grunt.loadNpmTasks('grunt-express-server');
     grunt.loadNpmTasks('grunt-jsbeautifier');
+    grunt.loadNpmTasks('grunt-exec');
 
     grunt.registerTask('default', ['jshint', 'express:dev', 'mochaTest']);
     grunt.registerTask('dev', ['jshint', 'jsbeautifier']);
+    grunt.registerTask('coverage', ['exec:coverage']);
 
     // Print a timestamp (useful for when watching)
     grunt.registerTask('timestamp', function () {
@@ -78,6 +80,9 @@ module.exports = function (grunt) {
                 },
                 src: ['test/unit/*.js', 'test/e2e/**/*.js', 'test/e2e/*.js']
             }
+        },
+        exec: {
+            coverage: './cover.sh'
         }
     });
 

--- a/cover.sh
+++ b/cover.sh
@@ -2,16 +2,16 @@
 # create output & pid dir if not already present
 mkdir -p test/coverage
 
-# run istanbul cover, save it's PID so we can kill it later, and pipe
-# it's output into file descriptor 3 so we can wait for the server to start
+# run istanbul cover, save its PID so we can kill it later, and pipe
+# its output into file descriptor 3 so we can wait for the server to start
 exec 3< <(./node_modules/.bin/istanbul cover server.js --dir ./test/coverage --handle-sigint & echo $! >test/coverage/pid)
 
-# wait til we see "Server listening..." to indicate the server's started, then
+# wait until we see "Server listening..." to indicate the server's started, then
 # kill sed
 # run cat to stop istanbul blocking fd 3 (see Stack Overflow #21001220)
 sed '/Server listening on port 3000$/q' <&3 ; cat <&3 &
 
-# runt tests
+# run tests
 grunt mochaTest
 
 # kill istanbul (--handle-sigint) ensures it generates coverage reports here

--- a/cover.sh
+++ b/cover.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# create output & pid dir if not already present
+mkdir -p test/coverage
+
+# run istanbul cover, save it's PID so we can kill it later, and pipe
+# it's output into file descriptor 3 so we can wait for the server to start
+exec 3< <(./node_modules/.bin/istanbul cover server.js --dir ./test/coverage --handle-sigint & echo $! >test/coverage/pid)
+
+# wait til we see "Server listening..." to indicate the server's started, then
+# kill sed
+# run cat to stop istanbul blocking fd 3 (see Stack Overflow #21001220)
+sed '/Server listening on port 3000$/q' <&3 ; cat <&3 &
+
+# runt tests
+grunt mochaTest
+
+# kill istanbul (--handle-sigint) ensures it generates coverage reports here
+kill -SIGINT $(<test/coverage/pid)

--- a/package.json
+++ b/package.json
@@ -67,7 +67,9 @@
     "grunt": "0.4.x",
     "grunt-contrib-jshint": "0.8.x",
     "grunt-contrib-watch": "0.6.x",
+    "grunt-exec": "^0.4.6",
     "grunt-express-server": "0.4.x",
-    "grunt-mocha-test": "0.10.x",    "grunt-jsbeautifier": "^0.2.8"
+    "grunt-mocha-test": "0.10.x",    "grunt-jsbeautifier": "^0.2.8",
+    "istanbul": "0.3.x"
   }
 }


### PR DESCRIPTION
Istanbul has a shell command `istanbul cover` that does exactly what we want (instrument and run a node script), so we can just run this on `server.js` and then run mocha tests.

Without separating out out `server.js` into discrete modules we can't pass a callback to wait for the server to start, and delays are more hackish, so we write a little bash wrapper to wait for expected output and then run tests, and then run that with `grunt-exec` (`coverage` task).

As it stands, 72% code coverage :)