### PR TITLE
Added one more record_type

### DIFF
--- a/lib/storage/index.js
+++ b/lib/storage/index.js
@@ -149,9 +149,9 @@ function getSavedRecords(username, saved_sections, callback) {
 }
 
 //Parses raw inbound records into components.
-function parseRecord(record_type, record_data, callback) {
+function parseRecord(record_type, record_data, callback) {   
     var supported_formats = ["ccda", "c32", "cda", "cms", "blue-button.js", "ncpdp"];
-    if (record_type === 'application/xml' || record_type === 'text/xml' || record_type === 'text/plain' || record_type === 'application/json') {
+    if (record_type === 'application/xml' || record_type === 'text/xml' || record_type === 'text/plain' || record_type === 'application/json' || record_type === 'text/xml; charset=utf8') {
         extractRecord(record_data, function (err, format_type, parsed_record) {
             if (err) {
                 callback(err);


### PR DESCRIPTION
In order to support JAVA API client, i have added new record_type. In general, multipart request type by default content-type set as 'application/octet-stream; charset=ISO-8859-1' in apache-httpclient
java package. Also we do not have API without encoding value. if we specifiy content type as 'text/xml', we are getting record_type as 'text/xml; charset=utf8' and getting parsing undefined error.
To resolve this issue, i have added one more record_type.

Signed-off-by: Loganathan loganathan.c@gmail.com
